### PR TITLE
Add /random endpoint for a random haiku

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,3 +33,12 @@ app.post('/redirect', (req, res) => {
   //redirect to haiku
   res.redirect('/' + req.body.id);
 });
+
+// Add a new GET route `/random` to serve a random haiku
+app.get('/random', (req, res) => {
+  // Use `Math.random()` to select a random haiku from `haikus.json`
+  const randomIndex = Math.floor(Math.random() * haikus.length);
+  const randomHaiku = haikus[randomIndex];
+  // Render the selected haiku using `views/random.ejs`
+  res.render('random', {haikus: [randomHaiku]});
+});


### PR DESCRIPTION
Related to #34

Adds a new feature to the application by introducing a `/random` endpoint that displays a single, randomly selected haiku and image.

- Implements a new GET route `/random` in `index.js` to serve a random haiku.
- Utilizes `Math.random()` to select a random haiku from `haikus.json`.
- Renders the selected haiku using a new template `views/random.ejs`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/peckjon/haikus-for-june/issues/34?shareId=befee470-0924-425b-8188-4b310ada11be).