### PR TITLE
Add random haiku view and GitHub login

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,32 +4,76 @@ let ejs = require('ejs');
 const haikus = require('./haikus.json');
 const port = process.env.PORT || 3000;
 
+const passport = require('passport');
+const GitHubStrategy = require('passport-github').Strategy;
+const session = require('express-session');
+
 app.use(express.static('public'))
 app.set('view engine', 'ejs');
 
+app.use(session({ secret: 'your-secret-key', resave: false, saveUninitialized: false }));
+app.use(passport.initialize());
+app.use(passport.session());
+
+passport.use(new GitHubStrategy({
+  clientID: process.env.GITHUB_CLIENT_ID,
+  clientSecret: process.env.GITHUB_CLIENT_SECRET,
+  callbackURL: "http://localhost:3000/auth/github/callback"
+},
+function(accessToken, refreshToken, profile, cb) {
+  return cb(null, profile);
+}));
+
+passport.serializeUser(function(user, cb) {
+  cb(null, user);
+});
+
+passport.deserializeUser(function(obj, cb) {
+  cb(null, obj);
+});
+
+function ensureAuthenticated(req, res, next) {
+  if (req.isAuthenticated()) {
+    return next();
+  }
+  res.redirect('/');
+}
+
 app.get('/', (req, res) => {
-  res.render('index', {haikus: haikus});
+  res.render('index', {haikus: haikus, user: req.user});
+});
+
+app.get('/random', (req, res) => {
+  const randomHaiku = haikus[Math.floor(Math.random() * haikus.length)];
+  res.render('index', {haikus: [randomHaiku], user: req.user});
+});
+
+app.get('/auth/github',
+  passport.authenticate('github'));
+
+app.get('/auth/github/callback', 
+  passport.authenticate('github', { failureRedirect: '/' }),
+  function(req, res) {
+    res.redirect('/');
+  });
+
+app.get('/logout', (req, res) => {
+  req.logout();
+  res.redirect('/');
 });
 
 app.listen(port, () => {
-
-  //print hikus to console
   console.log(haikus);
-
 });
 
-//get haiku by id
 app.get('/:id', (req, res) => {
-  res.render('index', {haikus: [haikus[req.params.id]]});
+  res.render('index', {haikus: [haikus[req.params.id]], user: req.user});
 });
 
-//get haiku by POST request
 app.post('/', (req, res) => {
-  res.render('index', {haikus: [haikus[req.body.id]]});
+  res.render('index', {haikus: [haikus[req.body.id]], user: req.user});
 });
 
-//redirect to haiku by POST request (vulnerable)
 app.post('/redirect', (req, res) => {
-  //redirect to haiku
   res.redirect('/' + req.body.id);
 });

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "dependencies": {
         "ejs": "^3.0.1",
         "express": "^4.17.1",
-        "nodemon": "^2.0.2"
+        "nodemon": "^2.0.2",
+        "passport": "^0.4.1",
+        "passport-github": "^1.1.0",
+        "express-session": "^1.17.1"
     },
     "devDependencies": {
         "gulp": "^4.0.2",

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -11,6 +11,16 @@
   <body>
     <h1>Haikus for June</h1>
     <div>
+      <% if (user) { %>
+        <a href="/logout">Logout</a>
+      <% } else { %>
+        <a href="/auth/github">Login with GitHub</a>
+      <% } %>
+    </div>
+    <div>
+      <a href="/random">View a random haiku</a>
+    </div>
+    <div>
       <% for(var i=0; i < haikus.length; i++) { %>
         <img
           class="june-images"


### PR DESCRIPTION
Related to #36

Add a view to show a random haiku and implement GitHub login functionality.

* **index.js**
  - Add a new route `/random` that renders a random haiku.
  - Add GitHub authentication using `passport`, `passport-github`, and `express-session`.
  - Add routes for GitHub login (`/auth/github`), GitHub login callback (`/auth/github/callback`), and logout (`/logout`).
  - Add middleware to check if the user is authenticated.
  - Pass the user object to the views.

* **views/index.ejs**
  - Add a GitHub login button.
  - Add a link to the random haiku view.
  - Add a logout button if the user is authenticated.

* **package.json**
  - Add `passport`, `passport-github`, and `express-session` to dependencies.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/peckjon/haikus-for-june/issues/36?shareId=756cab72-5cd7-45ad-9465-b4be35526426).