### PR TITLE
Add haiku as text overlay caption to image

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -24,6 +24,25 @@ body {
     white-space: pre-wrap;
 }
 
+.haiku-overlay {
+    position: relative;
+    display: inline-block;
+}
+
+.haiku-overlay img {
+    display: block;
+}
+
+.haiku-overlay .haikus {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: blue;
+    font-weight: bold;
+    text-align: center;
+}
+
 @media only screen and (max-width: 600px) {
     .june-images {
         max-width: 340px;

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -12,11 +12,10 @@
     <h1>Haikus for June</h1>
     <div>
       <% for(var i=0; i < haikus.length; i++) { %>
-        <img
-          class="june-images"
-          src="images/<%= haikus[i].image %>" />
-        <div 
-          class="haiku-containers">
+        <div class="haiku-overlay">
+          <img
+            class="june-images"
+            src="images/<%= haikus[i].image %>" />
           <p 
             class="haikus"
           ><%- haikus[i].text %></p>


### PR DESCRIPTION
Related to #40

Add the haiku as a text overlay caption to the image itself.

* **views/index.ejs**
  - Add a `div` with class `haiku-overlay` around the `img` tag.
  - Move the haiku text inside the `haiku-overlay` div.

* **public/css/main.css**
  - Add styles for the `haiku-overlay` class to position the text over the image.
  - Set the text color to blue and make it bold.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/peckjon/haikus-for-june/issues/40?shareId=859af638-35b0-4975-a277-096566728cc1).