### PR TITLE
Add haiku as text overlay caption to image

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -13,15 +13,31 @@ body {
     max-width: 400px;
     max-height: 400px;
     border: 8px solid #fff;
+    position: relative;
 }
 
 .haiku-containers {
     padding: 10px 0px 20px 0px;
+    position: relative;
 }
 
 .haikus {
     font-size: 18px;
     white-space: pre-wrap;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    color: #fff;
+    padding: 10px;
+    box-sizing: border-box;
+    opacity: 0;
+    transition: opacity 0.3s;
+}
+
+.june-images:hover .haikus {
+    opacity: 1;
 }
 
 @media only screen and (max-width: 600px) {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -12,14 +12,16 @@
     <h1>Haikus for June</h1>
     <div>
       <% for(var i=0; i < haikus.length; i++) { %>
-        <img
-          class="june-images"
-          src="images/<%= haikus[i].image %>" />
-        <div 
-          class="haiku-containers">
-          <p 
-            class="haikus"
-          ><%- haikus[i].text %></p>
+        <div class="image-container">
+          <img
+            class="june-images"
+            src="images/<%= haikus[i].image %>" />
+          <div 
+            class="haiku-containers">
+            <p 
+              class="haikus"
+            ><%- haikus[i].text %></p>
+          </div>
         </div>
       <% } %>
     </div>


### PR DESCRIPTION
Related to #40

Add the haiku as a text overlay caption to the image itself.

* **CSS Changes:**
  - Add styles for overlaying text on images.
  - Add styles for positioning the text at the bottom of the image.
  - Add styles for making the text visible only on hover.
  - Update `.june-images` class to have `position: relative`.
  - Update `.haikus` class to have `position: absolute`, `bottom: 0`, `left: 0`, `width: 100%`, `background-color: rgba(0, 0, 0, 0.5)`, `color: #fff`, `padding: 10px`, `box-sizing: border-box`, `opacity: 0`, and `transition: opacity 0.3s`.
  - Add hover effect to `.june-images:hover .haikus` to change `opacity` to `1`.

* **HTML Changes:**
  - Wrap the image and haiku text in a container div with class `image-container`.
  - Move the haiku text inside the container div.
  - Add a class to the haiku text for styling.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/peckjon/haikus-for-june/issues/40?shareId=acd07585-65db-4b80-96fd-3a938c737127).