### PR TITLE
Add hover textover caption to image

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -24,6 +24,21 @@ body {
     white-space: pre-wrap;
 }
 
+.haiku-caption {
+    position: absolute;
+    bottom: 10px;
+    left: 0;
+    width: 100%;
+    text-align: center;
+    font-weight: bold;
+    color: blue;
+    display: none;
+}
+
+.june-images:hover + .haiku-caption {
+    display: block;
+}
+
 @media only screen and (max-width: 600px) {
     .june-images {
         max-width: 340px;

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -12,9 +12,12 @@
     <h1>Haikus for June</h1>
     <div>
       <% for(var i=0; i < haikus.length; i++) { %>
-        <img
-          class="june-images"
-          src="images/<%= haikus[i].image %>" />
+        <div class="image-container">
+          <img
+            class="june-images"
+            src="images/<%= haikus[i].image %>" />
+          <div class="haiku-caption"><%- haikus[i].text %></div>
+        </div>
         <div 
           class="haiku-containers">
           <p 


### PR DESCRIPTION
Related to #40

Add a hover textover caption with the haiku in lower third, blue bold text to the image.

* **CSS changes:**
  - Add styles for the `haiku-caption` class to position the caption in the lower third of the image.
  - Add styles for the `haiku-caption` class to display blue bold text.
  - Add a `:hover` pseudo-class to the `haiku-caption` class to display the caption when the image is hovered over.

* **HTML changes:**
  - Update the `<img>` element to include a `<div>` element with the class `haiku-caption` containing the haiku text.
  - Position the `haiku-caption` element in the lower third of the image.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/peckjon/haikus-for-june/issues/40?shareId=41230112-dcee-4c54-b5cd-502a5da7a98c).