### PR TITLE
Add endpoint to return a random subset of haikus

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,14 @@ app.post('/random', (req, res) => {
   res.render('index', {haikus: [randomHaiku]});
 });
 
+//get a random subset of haikus
+app.get('/random-subset', (req, res) => {
+  const count = parseInt(req.query.count) || 3;
+  const shuffled = haikus.sort(() => 0.5 - Math.random());
+  const randomSubset = shuffled.slice(0, count);
+  res.render('index', {haikus: randomSubset});
+});
+
 // Export the app
 module.exports = app;
 

--- a/index.test.js
+++ b/index.test.js
@@ -1,4 +1,3 @@
-// index.test.js
 const request = require('supertest');
 const express = require('express');
 const app = require('./index');
@@ -30,5 +29,33 @@ describe('GET /:id', () => {
     const nonExistentId = haikus.length; // Out of bounds index
     const response = await request(app).get(`/${nonExistentId}`);
     expect(response.status).toBe(404);
+  });
+});
+
+describe('GET /random-subset', () => {
+  it('should return HTML with a random subset of haikus', async () => {
+    const response = await request(app).get('/random-subset');
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toMatch(/html/);
+    const haikuCount = (response.text.match(/<div class="haiku-containers">/g) || []).length;
+    expect(haikuCount).toBeGreaterThan(0);
+    expect(haikuCount).toBeLessThanOrEqual(3);
+  });
+
+  it('should return HTML with the specified number of haikus', async () => {
+    const count = 2;
+    const response = await request(app).get(`/random-subset?count=${count}`);
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toMatch(/html/);
+    const haikuCount = (response.text.match(/<div class="haiku-containers">/g) || []).length;
+    expect(haikuCount).toBe(count);
+  });
+
+  it('should use the default value of 3 when count is not specified', async () => {
+    const response = await request(app).get('/random-subset');
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toMatch(/html/);
+    const haikuCount = (response.text.match(/<div class="haiku-containers">/g) || []).length;
+    expect(haikuCount).toBe(3);
   });
 });


### PR DESCRIPTION
Related to #46

Add a new endpoint to show a random subset of haikus.

* Add a new endpoint `/random-subset` in `index.js` to return a random subset of haikus.
* Use a query parameter `count` to specify the number of haikus in the subset, with a default value of 3 if not specified.
* Reuse the existing view `index.ejs` to render the random subset of haikus.
* Add tests in `index.test.js` for the new endpoint `/random-subset` to check if it returns a random subset of haikus, if the `count` query parameter works correctly, and if the default value of `count` is used when not specified.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/peckjon/haikus-for-june/issues/46?shareId=XXXX-XXXX-XXXX-XXXX).